### PR TITLE
Potential fix for code scanning alert no. 1: Time-of-check time-of-use filesystem race condition

### DIFF
--- a/src/session.c
+++ b/src/session.c
@@ -187,7 +187,11 @@ int session_save_node_records(Session *s) {
     
     FILE *f = fopen(path, "w");
     if (!f) { perror("fopen"); return -1; }
-    chmod(path, 0600);
+    if (fchmod(fileno(f), 0600) == -1) {
+        perror("chmod");
+        fclose(f);
+        return -1;
+    }
 
     for (int i = 0; i < s->node_count; i++)
         fprintf(f, "%s %s\n", s->nodes[i].ip, s->nodes[i].user);


### PR DESCRIPTION
Potential fix for [https://github.com/phunga003/Topomap/security/code-scanning/1](https://github.com/phunga003/Topomap/security/code-scanning/1)

In general, to fix this class of problem you should avoid reusing the filename after opening the file, and instead apply subsequent operations (like permission changes) via the file descriptor obtained from the open. For permissions, that means replacing `chmod(path, mode)` with `fchmod(fd, mode)` using the descriptor from `open` or `fileno(f)`.

For this specific code, the best minimal fix is to change the post-`fopen` `chmod(path, 0600);` to an `fchmod` call on the file descriptor corresponding to `f`. We can obtain that descriptor via `fileno(f)`. This keeps the existing logic and API the same, but ensures the permission change is applied to the exact file that was opened, even if an attacker races to change the filesystem entry for `path` between the `fopen` and the permission change.

Concretely, in `src/session.c` around line 188:

- Replace `chmod(path, 0600);` with a guarded `fchmod(fileno(f), 0600);`.
- Handle potential errors from `fchmod` similarly to how `fopen` errors are handled (e.g., `perror("chmod");` followed by cleanup and returning `-1`), so that we don’t silently ignore a failed permission change.
- No new headers are strictly required on POSIX systems because `chmod`/`fchmod` and `fileno` are typically already available via existing headers like `<sys/stat.h>` and `<stdio.h>`, which are presumably included via `session.h` or elsewhere; therefore we avoid touching imports per the constraints.

No other functions in the shown snippet exhibit the same pattern, so only `session_save_node_records` needs to be updated.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
